### PR TITLE
BugFix: clear the current EventData after Drag

### DIFF
--- a/Unity Project/Packages/FarrokGames.Inventory/Runtime/InventoryController.cs
+++ b/Unity Project/Packages/FarrokGames.Inventory/Runtime/InventoryController.cs
@@ -146,6 +146,7 @@ namespace FarrokhGames.Inventory
                 }
 
                 _draggedItem = null;
+                _currentEventData = null;
             }
 
             /*


### PR DESCRIPTION
If the _currentEventData is not null after endDrag (For example, on mobile, transfer one item into another inventory), the item would not follow the player's input. (Tested)